### PR TITLE
Adapt test cases to pytest-asyncio 1.0 compatibility

### DIFF
--- a/tests/test_backoff_async.py
+++ b/tests/test_backoff_async.py
@@ -665,7 +665,7 @@ async def test_on_exception_callable_gen_kwargs():
 
 
 @pytest.mark.asyncio
-async def test_on_exception_coro_cancelling(event_loop):
+async def test_on_exception_coro_cancelling():
     sleep_started_event = asyncio.Event()
 
     @backoff.on_predicate(backoff.expo)
@@ -679,59 +679,10 @@ async def test_on_exception_coro_cancelling(event_loop):
 
         return False
 
-    task = event_loop.create_task(coro())
+    task = asyncio.create_task(coro())
 
     await sleep_started_event.wait()
 
     task.cancel()
 
     assert (await task)
-
-
-def test_on_predicate_on_regular_function_without_event_loop(monkeypatch):
-    monkeypatch.setattr('time.sleep', lambda x: None)
-
-    # Set default event loop to None.
-    loop = asyncio.get_event_loop()
-    asyncio.set_event_loop(None)
-
-    try:
-        @backoff.on_predicate(backoff.expo)
-        def return_true(log, n):
-            val = (len(log) == n - 1)
-            log.append(val)
-            return val
-
-        log = []
-        ret = return_true(log, 3)
-        assert ret is True
-        assert 3 == len(log)
-
-    finally:
-        # Restore event loop.
-        asyncio.set_event_loop(loop)
-
-
-def test_on_exception_on_regular_function_without_event_loop(monkeypatch):
-    monkeypatch.setattr('time.sleep', lambda x: None)
-
-    # Set default event loop to None.
-    loop = asyncio.get_event_loop()
-    asyncio.set_event_loop(None)
-
-    try:
-        @backoff.on_exception(backoff.expo, KeyError)
-        def keyerror_then_true(log, n):
-            if len(log) == n:
-                return True
-            e = KeyError()
-            log.append(e)
-            raise e
-
-        log = []
-        assert keyerror_then_true(log, 3) is True
-        assert 3 == len(log)
-
-    finally:
-        # Restore event loop.
-        asyncio.set_event_loop(loop)


### PR DESCRIPTION
- Remove deprecated event_loop fixture https://pytest-asyncio.readthedocs.io/en/stable/reference/changelog.html#removed
- Drop *_without_event_loop tests These incompatible tests (*1) are no longer needed since the underlying code has already been removed (introduced in a460156, removed in 5d714ccd).

*1: asyncio.get_event_loop() now raises a RuntimeError in Python 3.14
    when no loop exists.
    https://docs.python.org/3.14/whatsnew/3.14.html#id7

```
_____________________________________________________________________________________________ ERROR at setup of test_on_exception_coro_cancelling _____________________________________________________________________________________________
file /var/tmp/portage/dev-python/backoff-2.2.1/work/backoff-2.2.1/tests/test_backoff_async.py, line 667
  @pytest.mark.asyncio
  async def test_on_exception_coro_cancelling(event_loop):
      sleep_started_event = asyncio.Event()

      @backoff.on_predicate(backoff.expo)
      async def coro():
          sleep_started_event.set()

          try:
              await asyncio.sleep(10)
          except asyncio.CancelledError:
              return True

          return False

      task = event_loop.create_task(coro())

      await sleep_started_event.wait()

      task.cancel()

      assert (await task)
E       fixture 'event_loop' not found
>       available fixtures: _class_event_loop, _function_event_loop, _module_event_loop, _package_event_loop, _session_event_loop, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, capteesys, doctest_namespace, event_loop_policy, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, unused_tcp_port, unused_tcp_port_factory, unused_udp_port, unused_udp_port_factory
>       use 'pytest --fixtures [testpath]' for help on them.
```
```
__________________________________________________________________________________________ test_on_predicate_on_regular_function_without_event_loop ___________________________________________________________________________________________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f1ab5f52200>

    def test_on_predicate_on_regular_function_without_event_loop(monkeypatch):
        monkeypatch.setattr('time.sleep', lambda x: None)
    
        # Set default event loop to None.
>       loop = asyncio.get_event_loop()
               ^^^^^^^^^^^^^^^^^^^^^^^^

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f1ab5f52200>

tests/test_backoff_async.py:695: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <asyncio.unix_events._UnixDefaultEventLoopPolicy object at 0x7f1ab598e660>

    def get_event_loop(self):
        """Get the event loop for the current context.
    
        Returns an instance of EventLoop or raises an exception.
        """
        if self._local._loop is None:
>           raise RuntimeError('There is no current event loop in thread %r.'
                               % threading.current_thread().name)
E           RuntimeError: There is no current event loop in thread 'MainThread'.

self       = <asyncio.unix_events._UnixDefaultEventLoopPolicy object at 0x7f1ab598e660>

/usr/lib/python3.14/asyncio/events.py:718: RuntimeError
__________________________________________________________________________________________ test_on_exception_on_regular_function_without_event_loop ___________________________________________________________________________________________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f1ab5846190>

    def test_on_exception_on_regular_function_without_event_loop(monkeypatch):
        monkeypatch.setattr('time.sleep', lambda x: None)
    
        # Set default event loop to None.
>       loop = asyncio.get_event_loop()
               ^^^^^^^^^^^^^^^^^^^^^^^^

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f1ab5846190>

tests/test_backoff_async.py:719: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <asyncio.unix_events._UnixDefaultEventLoopPolicy object at 0x7f1ab598e660>

    def get_event_loop(self):
        """Get the event loop for the current context.
    
        Returns an instance of EventLoop or raises an exception.
        """
        if self._local._loop is None:
>           raise RuntimeError('There is no current event loop in thread %r.'
                               % threading.current_thread().name)
E           RuntimeError: There is no current event loop in thread 'MainThread'.

self       = <asyncio.unix_events._UnixDefaultEventLoopPolicy object at 0x7f1ab598e660>

/usr/lib/python3.14/asyncio/events.py:718: RuntimeError
```