### PR TITLE
fix: Added `logging.LoggerAdapter` to `backoff._typing._MaybeLogger` union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## Unreleased
 
-- Adapt test cases to pytest-asyncio 1.0 compatibility https://github.com/python-backoff/backoff/pull/1
+### Fixed
+
 - Use `inspect.iscoroutinefunction` instead of `asyncio.iscoroutinefunction` to avoid Python 3.14 deprecation warning https://github.com/python-backoff/backoff/pull/3
-- Use uv for dependencies and packaging https://github.com/python-backoff/backoff/pull/7
+- Adapt test cases to pytest-asyncio 1.0 compatibility https://github.com/python-backoff/backoff/pull/1 from @pastalian
 - Include tests in source distribution https://github.com/python-backoff/backoff/pull/13
+- Added `logging.LoggerAdapter` to `_MaybeLogger` union https://github.com/python-backoff/backoff/pull/34 from @jcbertin
+
+### Packaging
+
+- Use uv for dependencies and packaging https://github.com/python-backoff/backoff/pull/7
 
 ## [v2.2.1] - 2022-10-05
 

--- a/backoff/_typing.py
+++ b/backoff/_typing.py
@@ -38,7 +38,7 @@ _Handler = Union[
 ]
 _Jitterer = Callable[[float], float]
 _MaybeCallable = Union[T, Callable[[], T]]
-_MaybeLogger = Union[str, logging.Logger, None]
+_MaybeLogger = Union[str, logging.Logger, logging.LoggerAdapter, None]
 _MaybeSequence = Union[T, Sequence[T]]
 _Predicate = Callable[[T], bool]
 _WaitGenerator = Callable[..., Generator[float, None, None]]


### PR DESCRIPTION
The docs say about `logging.LoggerAdapter`:

<blockquote>

An easy way in which you can pass contextual information to be output along with logging event information is to use the [`LoggerAdapter`](https://docs.python.org/3/library/logging.html#logging.LoggerAdapter) class. This class is designed to look like a [`Logger`](https://docs.python.org/3/library/logging.html#logging.Logger), so that you can call [`debug()`](https://docs.python.org/3/library/logging.html#logging.debug), [`info()`](https://docs.python.org/3/library/logging.html#logging.info), [`warning()`](https://docs.python.org/3/library/logging.html#logging.warning), [`error()`](https://docs.python.org/3/library/logging.html#logging.error), [`exception()`](https://docs.python.org/3/library/logging.html#logging.exception), [`critical()`](https://docs.python.org/3/library/logging.html#logging.critical) and [`log()`](https://docs.python.org/3/library/logging.html#logging.log). These methods have the same signatures as their counterparts in [`Logger`](https://docs.python.org/3/library/logging.html#logging.Logger), so you can use the two types of instances interchangeably.

</blockquote>

cc @jcbertin

## Related

- https://github.com/litl/backoff/pull/225