### PR TITLE
Improve performance of expo by multiplying previous result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Use `time.monotonic` instead of `datetime.datetime.now` https://github.com/python-backoff/backoff/pull/23 (from @luccabb)
 - Drop support for Python 3.7 https://github.com/python-backoff/backoff/pull/49 (from @edgarrmondragon)
+- Improve performance of expo by multiplying previous result https://github.com/python-backoff/backoff/pull/50 (from @whonore)
 
 ## [v2.2.2] - 2025-11-17
 

--- a/backoff/_wait_gen.py
+++ b/backoff/_wait_gen.py
@@ -22,12 +22,12 @@ def expo(
     """
     # Advance past initial .send() call
     yield  # type: ignore[misc]
-    n = 0
+    base_n: float = 1
     while True:
-        a = factor * base ** n
+        a = factor * base_n
         if max_value is None or a < max_value:
             yield a
-            n += 1
+            base_n *= base
         else:
             yield max_value
 

--- a/tests/test_wait_gen.py
+++ b/tests/test_wait_gen.py
@@ -67,6 +67,14 @@ def test_expo_max_value():
         assert expect == next(gen)
 
 
+def test_expo_max_value_factor():
+    gen = backoff.expo(factor=3, max_value=2 ** 4)
+    gen.send(None)
+    expected = [3 * 1, 3 * 2, 3 * 4, 16, 16, 16, 16]
+    for expect in expected:
+        assert expect == next(gen)
+
+
 def test_fibo():
     gen = backoff.fibo()
     gen.send(None)


### PR DESCRIPTION
- https://github.com/litl/backoff/pull/103