### PR TITLE
chore: Bump to v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [v2.3.0] - 2025-11-28
+
 ### Changed
 
 - Use `time.monotonic` instead of `datetime.datetime.now` https://github.com/python-backoff/backoff/pull/23 (from @luccabb)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-backoff"
-version = "2.2.2"
+version = "2.3.0"
 description = "Function decoration for backoff and retry"
 authors = [{ name = "Bob Green", email = "rgreen@aquent.com" }]
 maintainers = [{ name = "Edgar Ramírez-Mondragón", email = "edgarrm358@gmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1602,7 +1602,7 @@ wheels = [
 
 [[package]]
 name = "python-backoff"
-version = "2.2.2"
+version = "2.3.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
- Use `time.monotonic` instead of `datetime.datetime.now` https://github.com/python-backoff/backoff/pull/23 (from @luccabb)
- Drop support for Python 3.7 https://github.com/python-backoff/backoff/pull/49 (from @edgarrmondragon)
- Improve performance of expo by multiplying previous result https://github.com/python-backoff/backoff/pull/50 (from @whonore)
