### PR TITLE
docs: Remove duplicate headers in API reference docs

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -4,14 +4,10 @@ Complete API documentation for the backoff module.
 
 ## Decorators
 
-###  on_exception
-
 ::: backoff.on_exception
     options:
       show_root_heading: true
       show_source: true
-
-### on_predicate
 
 ::: backoff.on_predicate
     options:
@@ -20,28 +16,20 @@ Complete API documentation for the backoff module.
 
 ## Wait Generators
 
-### expo
-
 ::: backoff.expo
     options:
       show_root_heading: true
       show_source: true
-
-### fibo
 
 ::: backoff.fibo
     options:
       show_root_heading: true
       show_source: true
 
-### constant
-
 ::: backoff.constant
     options:
       show_root_heading: true
       show_source: true
-
-### runtime
 
 ::: backoff.runtime
     options:
@@ -50,14 +38,10 @@ Complete API documentation for the backoff module.
 
 ## Jitter Functions
 
-### full_jitter
-
 ::: backoff.full_jitter
     options:
       show_root_heading: true
       show_source: true
-
-### random_jitter
 
 ::: backoff.random_jitter
     options:


### PR DESCRIPTION
Signed-off-by: Edgar Ramírez Mondragón <edgarrm358@gmail.com>
