### PR TITLE
docs: Format Python code blocks in Markdown files with native Ruff support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,13 +43,15 @@ repos:
     hooks:
     -   id: doccmd
         name: Ruff format docs
+        language: python
         alias: ruff-format-docs
         args: ["--language", "python", "--no-pad-file", "--no-pad-groups", "--command", "ruff format", "docs/"]
         additional_dependencies:
-        - ruff==0.14.8
+        - ruff==0.15.0
     -   id: doccmd
         name: Ruff check fix docs
+        language: python
         alias: ruff-check-fix-docs
         args: ["--language", "python", "--no-pad-file", "--no-pad-groups", "--command", "ruff check --fix", "docs/"]
         additional_dependencies:
-        - ruff==0.14.8
+        - ruff==0.15.0

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -239,8 +239,9 @@ def upload_to_s3(bucket, key, data):
 @backoff.on_exception(
     backoff.expo,
     ClientError,
-    giveup=lambda e: e.response["Error"]["Code"]
-    != "ProvisionedThroughputExceededException",
+    giveup=lambda e: (
+        e.response["Error"]["Code"] != "ProvisionedThroughputExceededException"
+    ),
     max_time=30,
 )
 def write_to_dynamodb(table_name, item):

--- a/docs/user-guide/event-handlers.md
+++ b/docs/user-guide/event-handlers.md
@@ -178,15 +178,13 @@ logger = logging.getLogger(__name__)
 
 def structured_log_backoff(details):
     logger.warning(
-        json.dumps(
-            {
-                "event": "retry",
-                "function": details["target"].__name__,
-                "tries": details["tries"],
-                "wait": details["wait"],
-                "elapsed": details["elapsed"],
-            }
-        )
+        json.dumps({
+            "event": "retry",
+            "function": details["target"].__name__,
+            "tries": details["tries"],
+            "wait": details["wait"],
+            "elapsed": details["elapsed"],
+        })
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ docs = [
     "zensical==0.0.20",
 ]
 lint = [
-    "ruff>=0.12.9",
+    "ruff>=0.15.0",
 ]
 test = [
     "coverage>=7.2.7",
@@ -124,7 +124,7 @@ description = "format code"
 dependency_groups = [ "lint" ]
 commands = [
     [ "ruff", "check", "--fix", { replace = "posargs", default = [ "backoff", "tests" ], extend = true } ],
-    # [ "ruff", "format", { replace = "posargs", default = [ "backoff", "tests" ], extend = true } ],
+    [ "ruff", "format", { replace = "posargs", default = [ "backoff", "tests" ], extend = true } ],
 ]
 
 [tool.tox.env.lint]
@@ -177,7 +177,10 @@ package = [
 ]
 
 [tool.ruff]
+extend-include = ["docs/**/*.md"]
 line-length = 88
+preview = true
+required-version = ">=0.15"
 
 [tool.ruff.format]
 docstring-code-format = true


### PR DESCRIPTION
## Links

https://docs.astral.sh/ruff/formatter/#markdown-code-formatting
