### PR TITLE
fix: Updated the type annotation of the `exception` argument in `on_exception`, `on_predicate`, `retry_context` and `aretry_context` to correctly expect an exception type or a tuple of exception types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Measure elapsed time after function call [#187](https://github.com/python-backoff/backoff/pull/187)
+- Updated the type annotation of the `exception` argument in `on_exception`, `on_predicate`, `retry_context` and `aretry_context` to correctly expect an exception type or a tuple of exception types [#192](https://github.com/python-backoff/backoff/pull/192)
 
 ### Documentation
 

--- a/backoff/_async.py
+++ b/backoff/_async.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
         _Handler,
         _Jitterer,
         _MaybeCallable,
-        _MaybeSequence,
+        _MaybeTuple,
         _Predicate,
         _WaitGenerator,
     )
@@ -159,7 +159,7 @@ def retry_predicate(
 def retry_exception(
     target: Callable[P, T],
     wait_gen: _WaitGenerator,
-    exception: _MaybeSequence[type[Exception]],
+    exception: _MaybeTuple[type[Exception]],
     *,
     max_tries: _MaybeCallable[int] | None,
     max_time: _MaybeCallable[float] | None,
@@ -203,7 +203,7 @@ def retry_exception(
 
             try:
                 ret = await target(*args, **kwargs)  # type: ignore[misc] # ty:ignore[invalid-await]
-            except exception as e:  # type: ignore[misc] # ty:ignore[invalid-exception-caught]
+            except exception as e:
                 details["elapsed"] = state.record_elapsed()
                 giveup_result = await giveup(e)
 
@@ -248,7 +248,7 @@ async def _dispatch_handlers(
 
 
 async def aretry_context(
-    exception: _MaybeSequence[type[Exception]],
+    exception: _MaybeTuple[type[Exception]],
     wait_gen: _WaitGenerator,
     *,
     max_tries: _MaybeCallable[int] | None,
@@ -271,7 +271,7 @@ async def aretry_context(
     )
     while True:
         state.start_attempt()
-        attempt = _Attempt(exception)  # type: ignore[arg-type] # ty:ignore[invalid-argument-type]
+        attempt = _Attempt(exception)
         yield attempt
         elapsed = state.record_elapsed()
 

--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
         _Jitterer,
         _MaybeCallable,
         _MaybeLogger,
-        _MaybeSequence,
+        _MaybeTuple,
         _Predicate,
         _WaitGenerator,
     )
@@ -143,7 +143,7 @@ def on_predicate(
 
 def on_exception(
     wait_gen: _WaitGenerator,
-    exception: _MaybeSequence[type[Exception]],
+    exception: _MaybeTuple[type[Exception]],
     *,
     max_tries: _MaybeCallable[int] | None = None,
     max_time: _MaybeCallable[float] | None = None,
@@ -247,7 +247,7 @@ def on_exception(
 
 
 def retry_context(
-    exception: _MaybeSequence[type[Exception]] = Exception,
+    exception: _MaybeTuple[type[Exception]] = Exception,
     wait_gen: _WaitGenerator = expo,
     *,
     max_tries: _MaybeCallable[int] | None = None,
@@ -343,7 +343,7 @@ def retry_context(
 
 
 def aretry_context(
-    exception: _MaybeSequence[type[Exception]] = Exception,
+    exception: _MaybeTuple[type[Exception]] = Exception,
     wait_gen: _WaitGenerator = expo,
     *,
     max_tries: _MaybeCallable[int] | None = None,

--- a/backoff/_sync.py
+++ b/backoff/_sync.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
         _Handler,
         _Jitterer,
         _MaybeCallable,
-        _MaybeSequence,
+        _MaybeTuple,
         _Predicate,
         _WaitGenerator,
     )
@@ -117,7 +117,7 @@ def retry_predicate(
 def retry_exception(
     target: Callable[P, T],
     wait_gen: _WaitGenerator,
-    exception: _MaybeSequence[type[Exception]],
+    exception: _MaybeTuple[type[Exception]],
     *,
     max_tries: _MaybeCallable[int] | None,
     max_time: _MaybeCallable[float] | None,
@@ -149,7 +149,7 @@ def retry_exception(
 
             try:
                 ret = target(*args, **kwargs)
-            except exception as e:  # type: ignore[misc] # ty:ignore[invalid-exception-caught]
+            except exception as e:
                 details["elapsed"] = state.record_elapsed()
 
                 if giveup(e) or state.exhausted():
@@ -177,7 +177,7 @@ def retry_exception(
 
 
 def retry_context(
-    exception: _MaybeSequence[type[Exception]],
+    exception: _MaybeTuple[type[Exception]],
     wait_gen: _WaitGenerator,
     *,
     max_tries: _MaybeCallable[int] | None,
@@ -198,7 +198,7 @@ def retry_context(
     )
     while True:
         state.start_attempt()
-        attempt = _Attempt(exception)  # type: ignore[arg-type] # ty:ignore[invalid-argument-type]
+        attempt = _Attempt(exception)
         yield attempt
         elapsed = state.record_elapsed()
 

--- a/backoff/_typing.py
+++ b/backoff/_typing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Coroutine, Generator, Sequence
+from collections.abc import Coroutine, Generator
 from typing import (
     Any,
     Callable,
@@ -60,7 +60,7 @@ _ContextHandler = Union[
 _Jitterer = Callable[[float], float]
 _MaybeCallable = Union[T, Callable[[], T]]
 _MaybeLogger = Union[str, logging.Logger, logging.LoggerAdapter, None]
-_MaybeSequence = Union[T, Sequence[T]]
+_MaybeTuple = Union[T, tuple[T, ...]]
 _Predicate = Union[
     Callable[[T], bool],
     Callable[[T], Coroutine[Any, Any, bool]],


### PR DESCRIPTION
SSIA
