### PR TITLE
fix!: Drop support for nullary (i.e. zero-argument) jitter functions

### DIFF
--- a/backoff/_common.py
+++ b/backoff/_common.py
@@ -4,7 +4,6 @@ import functools
 import logging
 import time
 import traceback
-import warnings
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 if TYPE_CHECKING:
@@ -64,18 +63,7 @@ def _next_wait(
     max_time: float | None,
 ) -> float:
     value = wait.send(send_value)
-    try:
-        seconds = jitter(value) if jitter is not None else value
-    except TypeError:
-        warnings.warn(
-            "Nullary jitter function signature is deprecated. Use "
-            "unary signature accepting a wait value in seconds and "
-            "returning a jittered version of it.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        seconds = value + jitter()  # type: ignore[call-arg, misc] # ty:ignore[missing-argument]
+    seconds = jitter(value) if jitter is not None else value
 
     # don't sleep longer than remaining allotted max_time
     if max_time is not None:

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -540,9 +540,7 @@ def test_on_predicate_iterable_handlers() -> None:
         }
 
 
-# To maintain backward compatibility,
-# on_predicate should support 0-argument jitter function.
-def test_on_exception_success_0_arg_jitter(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_on_exception_jitter(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("time.sleep", lambda x: None)
 
     backoffs: list[Details] = []
@@ -555,7 +553,7 @@ def test_on_exception_success_0_arg_jitter(monkeypatch: pytest.MonkeyPatch) -> N
         on_success=successes.append,
         on_backoff=backoffs.append,
         on_giveup=giveups.append,
-        jitter=lambda: 0.0,  # type:ignore[arg-type,misc] # ty:ignore[invalid-argument-type]
+        jitter=lambda value: 0.0,
         interval=0,
     )
     @_save_target
@@ -564,10 +562,7 @@ def test_on_exception_success_0_arg_jitter(monkeypatch: pytest.MonkeyPatch) -> N
         if len(backoffs) < 2:
             raise ValueError("catch me")
 
-    with pytest.deprecated_call(
-        match="Nullary jitter function signature is deprecated",
-    ):
-        succeeder(1, 2, 3, foo=1, bar=2)
+    succeeder(1, 2, 3, foo=1, bar=2)
 
     # we try 3 times, backing off twice before succeeding
     assert len(successes) == 1
@@ -596,9 +591,7 @@ def test_on_exception_success_0_arg_jitter(monkeypatch: pytest.MonkeyPatch) -> N
     }
 
 
-# To maintain backward compatibility,
-# on_predicate should support 0-argument jitter function.
-def test_on_predicate_success_0_arg_jitter(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_on_predicate_jitter(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("time.sleep", lambda x: None)
 
     backoffs: list[Details] = []
@@ -610,7 +603,7 @@ def test_on_predicate_success_0_arg_jitter(monkeypatch: pytest.MonkeyPatch) -> N
         on_success=successes.append,
         on_backoff=backoffs.append,
         on_giveup=giveups.append,
-        jitter=lambda: 0.0,  # type:ignore[arg-type,misc] # ty:ignore[invalid-argument-type]
+        jitter=lambda value: 0.0,
         interval=0,
     )
     @_save_target
@@ -618,10 +611,7 @@ def test_on_predicate_success_0_arg_jitter(monkeypatch: pytest.MonkeyPatch) -> N
         # succeed after we've backed off twice
         return len(backoffs) == 2
 
-    with pytest.deprecated_call(
-        match="Nullary jitter function signature is deprecated",
-    ):
-        success(1, 2, 3, foo=1, bar=2)
+    success(1, 2, 3, foo=1, bar=2)
 
     # we try 3 times, backing off twice before succeeding
     assert len(successes) == 1

--- a/tests/test_backoff_async.py
+++ b/tests/test_backoff_async.py
@@ -519,12 +519,8 @@ async def test_on_predicate_constant_iterable(monkeypatch: pytest.MonkeyPatch) -
     assert len(successes) == 0
 
 
-# To maintain backward compatibility,
-# on_predicate should support 0-argument jitter function.
 @pytest.mark.asyncio
-async def test_on_exception_success_0_arg_jitter(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_on_exception_jitter(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("asyncio.sleep", _await_none)
 
     log, log_success, log_backoff, log_giveup = _log_hdlrs()
@@ -535,7 +531,7 @@ async def test_on_exception_success_0_arg_jitter(
         on_success=log_success,
         on_backoff=log_backoff,
         on_giveup=log_giveup,
-        jitter=lambda: 0.0,  # type:ignore[arg-type,misc] # ty:ignore[invalid-argument-type]
+        jitter=lambda value: 0.0,
         interval=0,
     )
     @_save_target
@@ -544,10 +540,7 @@ async def test_on_exception_success_0_arg_jitter(
         if len(log["backoff"]) < 2:
             raise ValueError("catch me")
 
-    with pytest.deprecated_call(
-        match="Nullary jitter function signature is deprecated",
-    ):
-        await succeeder(1, 2, 3, foo=1, bar=2)
+    await succeeder(1, 2, 3, foo=1, bar=2)
 
     # we try 3 times, backing off twice before succeeding
     assert len(log["success"]) == 1
@@ -576,12 +569,8 @@ async def test_on_exception_success_0_arg_jitter(
     }
 
 
-# To maintain backward compatibility,
-# on_predicate should support 0-argument jitter function.
 @pytest.mark.asyncio
-async def test_on_predicate_success_0_arg_jitter(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_on_predicate_jitter(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("asyncio.sleep", _await_none)
 
     log, log_success, log_backoff, log_giveup = _log_hdlrs()
@@ -591,7 +580,7 @@ async def test_on_predicate_success_0_arg_jitter(
         on_success=log_success,
         on_backoff=log_backoff,
         on_giveup=log_giveup,
-        jitter=lambda: 0.0,  # type:ignore[arg-type,misc] # ty:ignore[invalid-argument-type]
+        jitter=lambda value: 0.0,
         interval=0,
     )
     @_save_target
@@ -599,10 +588,7 @@ async def test_on_predicate_success_0_arg_jitter(
         # succeed after we've backed off twice
         return len(log["backoff"]) == 2
 
-    with pytest.deprecated_call(
-        match="Nullary jitter function signature is deprecated",
-    ):
-        await success(1, 2, 3, foo=1, bar=2)
+    await success(1, 2, 3, foo=1, bar=2)
 
     # we try 3 times, backing off twice before succeeding
     assert len(log["success"]) == 1


### PR DESCRIPTION
Drops support for nullary jitter functions. They have to be unary functions now.

Closes https://github.com/python-backoff/backoff/issues/180.